### PR TITLE
Fix isOrientationPortrait is undefined

### DIFF
--- a/lib/useDeviceOrientation.js
+++ b/lib/useDeviceOrientation.js
@@ -3,14 +3,14 @@ import { Dimensions } from 'react-native';
 
 const screen = Dimensions.get('screen');
 
+const isOrientationPortrait = ({ width, height }) => height >= width;
+const isOrientationLandscape = ({ width, height }) => width >= height;
+
 export default () => {
   const [orientation, setOrientation] = useState({
     portrait: isOrientationPortrait(screen),
     landscape: isOrientationLandscape(screen)
   });
-
-  isOrientationPortrait = ({ width, height }) => height >= width;
-  isOrientationLandscape = ({ width, height }) => width >= height;
 
   onChange = ({ screen }) => {
     setOrientation({


### PR DESCRIPTION
The "useDeviceOrientation" hook cant be called because isOrientationPortrait function is defined after being used 