### PR TITLE
useAppState: useEffect should declare none deps to avoid trigger each render

### DIFF
--- a/lib/useAppState.js
+++ b/lib/useAppState.js
@@ -16,7 +16,7 @@ export default () => {
     return () => {
       AppState.removeEventListener('change', onChange)
     }
-  })
+  },[])
 
   return appState
 }


### PR DESCRIPTION
At the moment useAppState does not declare its dependencies (none) in useEffect hook.  
Direct consequence is that useEffect is called for each render of the component that useAppState.  
Still works but triggers unnecessary add/remove listeners.
Fix: declare [] (none) as useEffect deps.