### PR TITLE
no need of multiple useEffect

### DIFF
--- a/lib/useNetInfo.js
+++ b/lib/useNetInfo.js
@@ -16,9 +16,6 @@ export default () => {
     NetInfo.getConnectionInfo().then((connectionInfo) => {
       setNetInfo(connectionInfo)
     })
-  }, [])
-
-  useEffect(() => {
     NetInfo.addEventListener('connectionChange', onChange)
 
     return () => {


### PR DESCRIPTION
There are multiple useEffect hooks used and both of the useEffect hooks are going to call for only once so they can merge into the single useEffect hook.