### PR TITLE
Fix keyboard hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,8 @@ import { useKeyboard } from 'react-native-hooks'
 
 const keyboard = useKeyboard()
 
-console.log('keyboard show: ', keyboard.show)
-console.log('keyboard height: ', keyboard.height)
+console.log('keyboard isKeyboardShow: ', keyboard.isKeyboardShow)
+console.log('keyboard keyboardHeight: ', keyboard.keyboardHeight)
 ```
 
 ### `useInteractionManager`

--- a/lib/useKeyboard.js
+++ b/lib/useKeyboard.js
@@ -4,14 +4,14 @@ import { Keyboard } from 'react-native'
 export default () => {
   const [keyboard, setKeyboard] = useState({})
 
-  keyboardDidShow = e => {
+  const keyboardDidShow = e => {
     setKeyboard({
       isKeyboardShow: true,
       keyboardHeight: e.endCoordinates.height
     })
   }
 
-  keyboardDidHide = e => {
+  const keyboardDidHide = e => {
     setKeyboard({
       isKeyboardShow: false,
       keyboardHeight: e ? e.endCoordinates.height : null

--- a/lib/useKeyboard.js
+++ b/lib/useKeyboard.js
@@ -4,33 +4,33 @@ import { Keyboard } from 'react-native'
 export default () => {
   const [keyboard, setKeyboard] = useState({})
 
-  keyboardWillShow = e => {
+  keyboardDidShow = e => {
     setKeyboard({
       isKeyboardShow: true,
       keyboardHeight: e.endCoordinates.height
     })
   }
 
-  keyboardWillHide = e => {
+  keyboardDidHide = e => {
     setKeyboard({
       isKeyboardShow: false,
-      keyboardHeight: e.endCoordinates.height
+      keyboardHeight: e ? e.endCoordinates.height : null
     })
   }
 
   useEffect(() => {
-    this.keyboardWillShowListener = Keyboard.addListener(
-      'keyboardWillShow',
-      keyboardWillShow
+    this.keyboardDidShowListener = Keyboard.addListener(
+      'keyboardDidShow',
+      keyboardDidShow
     )
-    this.keyboardWillHideListener = Keyboard.addListener(
-      'keyboardWillHide',
-      keyboardWillHide
+    this.keyboardDidHideListener = Keyboard.addListener(
+      'keyboardDidHide',
+      keyboardDidHide
     )
 
     return () => {
-      this.keyboardWillShowListener.remove()
-      this.keyboardWillHideListener.remove()
+      this.keyboardDidShowListener.remove()
+      this.keyboardDidHideListener.remove()
     }
   }, [])
   return keyboard


### PR DESCRIPTION
# Summary

Solves #17 

Using `keyboardDidShow` and `keyboardDidHide` events instead of `keyboardWillShow` and `keyboardWillHide` that [aren't available on iOS](https://facebook.github.io/react-native/docs/keyboard):

> keyboardWillShow as well as keyboardWillHide are generally not available on Android since there is no native corresponding event.


## Test Plan

Works fine now on Android as well as iOS.

### What's required for testing (prerequisites)?

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [ ] I updated the typed files (TS and Flow)
- [x] I added a sample use of the API in the example project (`example/App.js`)
