### PR TITLE
add useLayout hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,3 +132,16 @@ const orientation = useDeviceOrientation()
 console.log('is orientation portrait: ', orientation.portrait)
 console.log('is orientation landscape: ', orientation.landscape)
 ```
+
+### `useLayout`
+
+```js
+import { useLayout } from 'react-native-hooks'
+
+const {x, y, width, height, onLayout}  = useLayout()
+
+<View onLayout={onLayout}>
+  <View style={{width: width, height: width, backgroundColor: 'red'}} />
+  <View style={{width: width, height: width, backgroundColor: 'green'}} />
+</View>
+```

--- a/lib/useLayout.js
+++ b/lib/useLayout.js
@@ -1,0 +1,13 @@
+export default function useLayout() {
+    const [layout, setLayout] = React.useState({
+        x: 0,
+        y: 0,
+        width: 0,
+        height: 0,
+    })
+    const onLayout = React.useCallback(e => setLayout(e.nativeEvent.layout), [])
+    return {
+        onLayout,
+        ...layout,
+    }
+}


### PR DESCRIPTION
# Summary

- Adding a `useLayout` hook.
- This can be used to get the dimensions of a view and use them to style another view, as shown in the readme.

## Test Plan

- I'm using this hook in an app.
- This project doesn't seem to have a lot of testing.
- I think it would be beneficial to use TypeScript for this, which is what I originally wrote the code in. I could submit a PR converting this project to TypeScript if that's acceptable.

### What's required for testing (prerequisites)?

- Something like what is shown in the readme.

### What are the steps to reproduce (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md` N/A
- [ ] I updated the typed files (TS and Flow) N/A
- [ ] I added a sample use of the API in the example project (`example/App.js`) N/A
