### PR TITLE
Update useClipboard useEffect to support async functions

### DIFF
--- a/lib/useClipboard.js
+++ b/lib/useClipboard.js
@@ -4,9 +4,12 @@ import { Clipboard } from 'react-native'
 export default () => {
   const [data, updateClipboardData] = useState('')
 
-  useEffect(async () => {
-    const content = await Clipboard.getString()
-    updateClipboardData(content)
+  useEffect(() => {
+    async function updateClipboard() {
+        const content = await Clipboard.getString()
+        updateClipboardData(content);
+    }
+    updateClipboard()
   }, [])
 
   function setString(content) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
The implementation does not align with hooks best practices. useEffect does not work with async functions as a parameter. They should be declared and invoked in useEffect body.
