### PR TITLE
fix onChange array functions

### DIFF
--- a/lib/useDeviceOrientation.js
+++ b/lib/useDeviceOrientation.js
@@ -12,7 +12,7 @@ export default function() {
     landscape: isOrientationLandscape(screen)
   });
 
-  onChange = ({ screen }) => {
+  const onChange = ({ screen }) => {
     setOrientation({
       portrait: isOrientationPortrait(screen),
       landscape: isOrientationLandscape(screen)

--- a/lib/useDimensions.js
+++ b/lib/useDimensions.js
@@ -9,7 +9,7 @@ export default function useDimensions() {
     window, screen
   })
 
-  onChange = ({ window, screen }) => {
+  const onChange = ({ window, screen }) => {
     setDimensions({ window, screen })
   }
 


### PR DESCRIPTION
# Summary

Fix onChange in `useDeviceOrientation` and `useDimensions` array fonction.

Define the `const` to fix serious issues that can happen if you already had a function called `onChange` inside the component that use those hooks.

