### PR TITLE
Fix useAppState dependencies list

### DIFF
--- a/lib/useAppState.js
+++ b/lib/useAppState.js
@@ -15,7 +15,7 @@ export default function useAppState() {
     return () => {
       AppState.removeEventListener('change', onChange)
     }
-  })
+  }, [])
 
   return appState
 }


### PR DESCRIPTION
This was already fixed with [this PR](https://github.com/react-native-community/react-native-hooks/pull/14) but it looks that you had a regression in [this commit](https://github.com/react-native-community/react-native-hooks/commit/2be886e1ee6edab19f3d8c784ea2cc89ebc56193#diff-8c0d60c71e94d3c1a12fa36e5c2130fdL19) and reverted the fix