### PR TITLE
Make sure initial dimensions are up-to-date

### DIFF
--- a/src/useDimensions.ts
+++ b/src/useDimensions.ts
@@ -1,13 +1,11 @@
 import {useEffect, useState} from 'react'
 import {Dimensions, ScaledSize} from 'react-native'
 
-const initialState = {
-  window: Dimensions.get('window'),
-  screen: Dimensions.get('screen'),
-}
-
 export default function useDimensions() {
-  const [dimensions, setDimensions] = useState(initialState)
+  const [dimensions, setDimensions] = useState({
+    window: Dimensions.get('window'),
+    screen: Dimensions.get('screen'),
+  })
 
   const onChange = ({
     window,


### PR DESCRIPTION
# Summary

Before this change, starting the app in portrait, then switching to landscape mode, and after that loading a screen that uses `useDimensions` would result in the original values being returned before the `change` event fires.

## Test Plan

The buggy behaviour can easily be observed before this patch. After I applied the patch I tried again and it was working properly 👍 

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ✅     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [n/a] I added the documentation in `README.md`
- [ ] I mentioned this change in `CHANGELOG.md`
- [n/a] I updated the typed files (TS and Flow)
- [n/a] I added a sample use of the API in the example project (`example/App.js`)
